### PR TITLE
Allow for multiple now and next events

### DIFF
--- a/cli/src/commands/now_next.rs
+++ b/cli/src/commands/now_next.rs
@@ -59,8 +59,8 @@ pub(crate) fn run(args: NowNextOptions, mut schedule: Schedule) {
     table.print(table_data);
 }
 
-fn format_event_now(event: &Option<Event>) -> String {
-    match event {
+fn format_event_now(events: &[Event]) -> String {
+    match events.first() {
         Some(event) => format!(
             ">{} [{}] {}",
             event.end.format("%H:%M"),
@@ -71,8 +71,8 @@ fn format_event_now(event: &Option<Event>) -> String {
     }
 }
 
-fn format_event_next(event: &Option<Event>) -> String {
-    match event {
+fn format_event_next(events: &[Event]) -> String {
+    match events.first() {
         Some(event) => format!(
             "@{} [{}] {}",
             event.start.format("%H:%M"),

--- a/client/src/schedule/now_and_next.rs
+++ b/client/src/schedule/now_and_next.rs
@@ -20,14 +20,20 @@ impl NowAndNext {
             result.guide.insert(
                 venue.clone(),
                 VenueNowAndNext {
-                    now: events
+                    now: match events
                         .iter()
                         .find(|e| e.venue == venue && e.relative_to(now) == RelativeTime::Now)
-                        .cloned(),
-                    next: events
+                    {
+                        Some(e) => vec![e.clone()],
+                        None => Vec::default(),
+                    },
+                    next: match events
                         .iter()
                         .find(|e| e.venue == venue && e.relative_to(now) == RelativeTime::Future)
-                        .cloned(),
+                    {
+                        Some(e) => vec![e.clone()],
+                        None => Vec::default(),
+                    },
                 },
             );
         }
@@ -39,11 +45,11 @@ impl NowAndNext {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct VenueNowAndNext {
     /// An event is "now" if the query time is between its start and end timestamps.
-    pub now: Option<Event>,
+    pub now: Vec<Event>,
 
     /// An event is "next" if is the first event in chronological order to have a start timestamp
     /// that is later than the query timestamp.
-    pub next: Option<Event>,
+    pub next: Vec<Event>,
 }
 
 #[cfg(test)]
@@ -84,11 +90,11 @@ mod test {
 
         assert_eq!(now_and_next.guide.len(), 2);
 
-        assert_eq!(now_and_next.guide["venue 1"].now, Some(events[0].clone()));
-        assert_eq!(now_and_next.guide["venue 1"].next, Some(events[2].clone()));
+        assert_eq!(now_and_next.guide["venue 1"].now, vec![events[0].clone()]);
+        assert_eq!(now_and_next.guide["venue 1"].next, vec![events[2].clone()]);
 
-        assert_eq!(now_and_next.guide["venue 2"].now, Some(events[1].clone()));
-        assert_eq!(now_and_next.guide["venue 2"].next, None);
+        assert_eq!(now_and_next.guide["venue 2"].now, vec![events[1].clone()]);
+        assert_eq!(now_and_next.guide["venue 2"].next, Vec::default());
     }
 
     #[test]
@@ -124,10 +130,10 @@ mod test {
 
         assert_eq!(now_and_next.guide.len(), 2);
 
-        assert_eq!(now_and_next.guide["venue 1"].now, None);
-        assert_eq!(now_and_next.guide["venue 1"].next, Some(events[0].clone()));
+        assert_eq!(now_and_next.guide["venue 1"].now, Vec::default());
+        assert_eq!(now_and_next.guide["venue 1"].next, vec![events[0].clone()]);
 
-        assert_eq!(now_and_next.guide["venue 2"].now, None);
-        assert_eq!(now_and_next.guide["venue 2"].next, Some(events[1].clone()));
+        assert_eq!(now_and_next.guide["venue 2"].now, Vec::default());
+        assert_eq!(now_and_next.guide["venue 2"].next, vec![events[1].clone()]);
     }
 }


### PR DESCRIPTION
This allows for multiple now and next events in the response types used in the client and adapter.

It does not allow the client to return multiple now/next events or allow the CLI to display them, this will be done later.

Multiple events should not really be a common issue, but it did happen in 2022, so might happen again, who knows.
May as well handle it correctly if it does happen though.

Re #13

cc @IainYa