### PR TITLE
Remove extra fields from events

### DIFF
--- a/client/src/announcer/test/mod.rs
+++ b/client/src/announcer/test/mod.rs
@@ -10,11 +10,3 @@ mod t09;
 use super::*;
 use crate::testing::DummyScheduleServer;
 use tokio::time::{Duration, Instant};
-
-fn set_and_patch_dummy_events(server: &mut DummyScheduleServer, events: Vec<Event>) -> Vec<Event> {
-    // Load the events into the dummy/test server.
-    server.set_events(events.clone());
-
-    // Return the patched events for comparisons.
-    events
-}

--- a/client/src/announcer/test/mod.rs
+++ b/client/src/announcer/test/mod.rs
@@ -9,23 +9,11 @@ mod t09;
 
 use super::*;
 use crate::testing::DummyScheduleServer;
-use serde_json::Value;
-use std::collections::HashMap;
 use tokio::time::{Duration, Instant};
 
-fn set_and_patch_dummy_events(
-    server: &mut DummyScheduleServer,
-    mut events: Vec<Event>,
-) -> Vec<Event> {
+fn set_and_patch_dummy_events(server: &mut DummyScheduleServer, events: Vec<Event>) -> Vec<Event> {
     // Load the events into the dummy/test server.
     server.set_events(events.clone());
-
-    // Add "type" to extra fields to ensure equality checking works as expected.
-    // In theory this should not be needed, I assume there is some funkyness going on with the fact
-    // this field is renamed by serde.
-    for event in events.iter_mut() {
-        event.extra = HashMap::from([("type".to_string(), Value::String("talk".to_string()))]);
-    }
 
     // Return the patched events for comparisons.
     events

--- a/client/src/announcer/test/t02.rs
+++ b/client/src/announcer/test/t02.rs
@@ -6,13 +6,10 @@ async fn t02_schedule_is_refreshed_on_requested_schedule() {
 
     let now = Utc::now();
 
-    set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![Event::dummy(
-            0,
-            (now + ChronoDuration::try_minutes(1).unwrap()).into(),
-        )],
-    );
+    dummy_server.set_events(vec![Event::dummy(
+        0,
+        (now + ChronoDuration::try_minutes(1).unwrap()).into(),
+    )]);
 
     let client = Client::new(dummy_server.url());
 

--- a/client/src/announcer/test/t03.rs
+++ b/client/src/announcer/test/t03.rs
@@ -6,13 +6,10 @@ async fn t03_changes_to_the_schedule_are_noticed() {
 
     let now = Utc::now();
 
-    set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![Event::dummy(
-            0,
-            (now + ChronoDuration::try_minutes(1).unwrap()).into(),
-        )],
-    );
+    dummy_server.set_events(vec![Event::dummy(
+        0,
+        (now + ChronoDuration::try_minutes(1).unwrap()).into(),
+    )]);
 
     let client = Client::new(dummy_server.url());
 
@@ -27,13 +24,10 @@ async fn t03_changes_to_the_schedule_are_noticed() {
     .await
     .unwrap();
 
-    set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![Event::dummy(
-            1,
-            (now + ChronoDuration::try_minutes(1).unwrap()).into(),
-        )],
-    );
+    dummy_server.set_events(vec![Event::dummy(
+        1,
+        (now + ChronoDuration::try_minutes(1).unwrap()).into(),
+    )]);
 
     crate::assert_future_in!(
         announcer.poll(),

--- a/client/src/announcer/test/t04.rs
+++ b/client/src/announcer/test/t04.rs
@@ -6,14 +6,11 @@ async fn t04_basic_event_notification() {
 
     let now = Utc::now();
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
-            Event::dummy(1, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
+        Event::dummy(1, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+    ]);
 
     let client = Client::new(dummy_server.url());
 
@@ -32,19 +29,19 @@ async fn t04_basic_event_notification() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(1),
-        AnnouncerPollResult::Event(events[0].clone())
+        AnnouncerPollResult::Event(dummy_server.event(0))
     );
 
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(2),
-        AnnouncerPollResult::Event(events[1].clone())
+        AnnouncerPollResult::Event(dummy_server.event(1))
     );
 
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(3),
-        AnnouncerPollResult::Event(events[2].clone())
+        AnnouncerPollResult::Event(dummy_server.event(2))
     );
 
     dummy_server.stop().await;

--- a/client/src/announcer/test/t05.rs
+++ b/client/src/announcer/test/t05.rs
@@ -6,15 +6,12 @@ async fn t05_event_notification_with_multiple_identical_start_times() {
 
     let now = Utc::now();
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
-            Event::dummy(1, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
-            Event::dummy(3, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
+        Event::dummy(1, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
+        Event::dummy(3, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+    ]);
 
     let client = Client::new(dummy_server.url());
 
@@ -33,25 +30,25 @@ async fn t05_event_notification_with_multiple_identical_start_times() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(1),
-        AnnouncerPollResult::Event(events[0].clone())
+        AnnouncerPollResult::Event(dummy_server.event(0))
     );
 
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(2),
-        AnnouncerPollResult::Event(events[1].clone())
+        AnnouncerPollResult::Event(dummy_server.event(1))
     );
 
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(2),
-        AnnouncerPollResult::Event(events[2].clone())
+        AnnouncerPollResult::Event(dummy_server.event(2))
     );
 
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(3),
-        AnnouncerPollResult::Event(events[3].clone())
+        AnnouncerPollResult::Event(dummy_server.event(3))
     );
 
     dummy_server.stop().await;

--- a/client/src/announcer/test/t06.rs
+++ b/client/src/announcer/test/t06.rs
@@ -6,14 +6,11 @@ async fn t06_basic_event_notification_unsorted() {
 
     let now = Utc::now();
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(1, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
-            Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(1, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
+        Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+    ]);
 
     let client = Client::new(dummy_server.url());
 
@@ -32,19 +29,19 @@ async fn t06_basic_event_notification_unsorted() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(1),
-        AnnouncerPollResult::Event(events[1].clone())
+        AnnouncerPollResult::Event(dummy_server.event(1))
     );
 
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(2),
-        AnnouncerPollResult::Event(events[0].clone())
+        AnnouncerPollResult::Event(dummy_server.event(0))
     );
 
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(3),
-        AnnouncerPollResult::Event(events[2].clone())
+        AnnouncerPollResult::Event(dummy_server.event(2))
     );
 
     dummy_server.stop().await;

--- a/client/src/announcer/test/t07.rs
+++ b/client/src/announcer/test/t07.rs
@@ -6,14 +6,11 @@ async fn t07_event_notification_with_schedule_update() {
 
     let now = Utc::now();
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
-            Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
+        Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
+    ]);
 
     let client = Client::new(dummy_server.url());
 
@@ -32,7 +29,7 @@ async fn t07_event_notification_with_schedule_update() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(1),
-        AnnouncerPollResult::Event(events[0].clone())
+        AnnouncerPollResult::Event(dummy_server.event(0))
     );
 
     crate::assert_future_in!(
@@ -44,7 +41,7 @@ async fn t07_event_notification_with_schedule_update() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(3),
-        AnnouncerPollResult::Event(events[1].clone())
+        AnnouncerPollResult::Event(dummy_server.event(1))
     );
 
     crate::assert_future_in!(
@@ -62,7 +59,7 @@ async fn t07_event_notification_with_schedule_update() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(7),
-        AnnouncerPollResult::Event(events[2].clone())
+        AnnouncerPollResult::Event(dummy_server.event(2))
     );
 
     crate::assert_future_in!(

--- a/client/src/announcer/test/t08.rs
+++ b/client/src/announcer/test/t08.rs
@@ -6,14 +6,11 @@ async fn t08_future_changes_take_effect() {
 
     let now = Utc::now();
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
-            Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
+        Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
+    ]);
 
     let client = Client::new(dummy_server.url());
 
@@ -32,7 +29,7 @@ async fn t08_future_changes_take_effect() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(1),
-        AnnouncerPollResult::Event(events[0].clone())
+        AnnouncerPollResult::Event(dummy_server.event(0))
     );
 
     crate::assert_future_in!(
@@ -44,7 +41,7 @@ async fn t08_future_changes_take_effect() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(3),
-        AnnouncerPollResult::Event(events[1].clone())
+        AnnouncerPollResult::Event(dummy_server.event(1))
     );
 
     crate::assert_future_in!(
@@ -53,14 +50,11 @@ async fn t08_future_changes_take_effect() {
         AnnouncerPollResult::ScheduleRefreshed(AnnouncerScheduleChanges::NoChanges)
     );
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
-            Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(9).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
+        Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(9).unwrap()).into()),
+    ]);
 
     crate::assert_future_in!(
         announcer.poll(),
@@ -77,7 +71,7 @@ async fn t08_future_changes_take_effect() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(9),
-        AnnouncerPollResult::Event(events[2].clone())
+        AnnouncerPollResult::Event(dummy_server.event(2))
     );
 
     crate::assert_future_in!(

--- a/client/src/announcer/test/t09.rs
+++ b/client/src/announcer/test/t09.rs
@@ -6,14 +6,11 @@ async fn t09_changes_in_past_have_no_effect() {
 
     let now = Utc::now();
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
-            Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(0, (now + ChronoDuration::try_seconds(1).unwrap()).into()),
+        Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
+    ]);
 
     let client = Client::new(dummy_server.url());
 
@@ -32,7 +29,7 @@ async fn t09_changes_in_past_have_no_effect() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(1),
-        AnnouncerPollResult::Event(events[0].clone())
+        AnnouncerPollResult::Event(dummy_server.event(0))
     );
 
     crate::assert_future_in!(
@@ -44,7 +41,7 @@ async fn t09_changes_in_past_have_no_effect() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(3),
-        AnnouncerPollResult::Event(events[1].clone())
+        AnnouncerPollResult::Event(dummy_server.event(1))
     );
 
     crate::assert_future_in!(
@@ -53,14 +50,11 @@ async fn t09_changes_in_past_have_no_effect() {
         AnnouncerPollResult::ScheduleRefreshed(AnnouncerScheduleChanges::NoChanges)
     );
 
-    let events = set_and_patch_dummy_events(
-        &mut dummy_server,
-        vec![
-            Event::dummy(0, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
-            Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
-            Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
-        ],
-    );
+    dummy_server.set_events(vec![
+        Event::dummy(0, (now + ChronoDuration::try_seconds(2).unwrap()).into()),
+        Event::dummy(1, (now + ChronoDuration::try_seconds(3).unwrap()).into()),
+        Event::dummy(2, (now + ChronoDuration::try_seconds(7).unwrap()).into()),
+    ]);
 
     crate::assert_future_in!(
         announcer.poll(),
@@ -71,7 +65,7 @@ async fn t09_changes_in_past_have_no_effect() {
     crate::assert_future_in!(
         announcer.poll(),
         now_i + Duration::from_secs(7),
-        AnnouncerPollResult::Event(events[2].clone())
+        AnnouncerPollResult::Event(dummy_server.event(2))
     );
 
     crate::assert_future_in!(

--- a/client/src/schedule/event/mod.rs
+++ b/client/src/schedule/event/mod.rs
@@ -3,9 +3,8 @@ mod timestamp;
 
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use serde_with::{serde_as, NoneAsEmptyString};
-use std::{cmp::Ordering, collections::HashMap};
+use std::cmp::Ordering;
 use url::Url;
 
 pub use self::kind::{Kind, Workshop};
@@ -45,9 +44,6 @@ pub struct Event {
     pub is_family_friendly: Option<bool>,
 
     pub link: Url,
-
-    #[serde(flatten)]
-    pub extra: HashMap<String, Value>,
 }
 
 impl Event {
@@ -72,7 +68,6 @@ impl Event {
             may_record: None,
             is_family_friendly: None,
             link: Url::parse("http://example.com").unwrap(),
-            extra: HashMap::default(),
         }
     }
 

--- a/client/src/testing.rs
+++ b/client/src/testing.rs
@@ -52,6 +52,10 @@ impl DummyScheduleServer {
         *self.events.lock().unwrap() = events;
     }
 
+    pub(crate) fn event(&self, idx: usize) -> Event {
+        self.events.lock().unwrap()[idx].clone()
+    }
+
     pub(crate) async fn stop(&mut self) {
         if let Some(handle) = self.handle.take() {
             handle.abort();


### PR DESCRIPTION
This caused some odd behaviour when combined with the flattened enum used to store the type and type specific fields of the event.